### PR TITLE
Remove `fa` class to allow for FA v5 `fas` & `fab`

### DIFF
--- a/templates/FormGenerator/macros/text.html.twig
+++ b/templates/FormGenerator/macros/text.html.twig
@@ -1,7 +1,7 @@
 {% macro generate(input) %}
     {% if input.icon %}
     <div class="input-group">
-        <span class="input-group-addon"><i class="fa {{input.icon}} fa-fw"></i></span>
+        <span class="input-group-addon"><i class="{{input.icon}} fa-fw"></i></span>
     {% else %}
     <div class="form-group">
     {% endif %}

--- a/templates/FormGenerator/macros/textarea.html.twig
+++ b/templates/FormGenerator/macros/textarea.html.twig
@@ -1,5 +1,5 @@
 {% macro generate(input) %}
-    {% if input.icon %}<div class="input-group"><span class="input-group-addon"><i class="fa {{input.icon}} fa-fw"></i></span>{% endif %}
+    {% if input.icon %}<div class="input-group"><span class="input-group-addon"><i class="{{input.icon}} fa-fw"></i></span>{% endif %}
     <textarea{% for type,value in input %} {{type}}="{{value}}"{% endfor %}>{{input.value}}</textarea>
     {% if input.icon %}</div>{% endif %}
 {% endmacro %}


### PR DESCRIPTION
Font Awesome v5 has more than just the `fa` class. Removing the class from the template improves flexibility by allowing config via the schema